### PR TITLE
fix sd2 covariance in hetGP.predict

### DIFF
--- a/hetgpy/hetGP.py
+++ b/hetgpy/hetGP.py
@@ -1457,7 +1457,7 @@ class hetGP:
         kx = cov_gen(X1 = x, X2 = self['X0'], theta = self['theta'], type = self['covtype'])
 
         if self['trendtype'] == 'SK':
-            sd2 = self['nu_hat'] - np.diag(kx @ (self['Ki'] @ kx.T))
+            sd2 = self['nu_hat'] * (1 - np.diag(kx @ (self['Ki'] @ kx.T)))
         else:
             sd2 = self['nu_hat'] * (1 - np.diag(kx @ ((self['Ki'] @ kx.T)))  + (1- (self['Ki'].sum(axis=1))@ kx.T)**2/self['Ki'].sum())
             foo=1
@@ -1466,7 +1466,7 @@ class hetGP:
             warnings.warn("Numerical errors caused some negative predictive variances to be thresholded to zero. Consider using ginv via rebuild.homGP")
 
         if xprime is not None:
-            kxprime = self['nu_hat'] * cov_gen(X1 = self['X0'], X2 = xprime, theta = self['theta'], type = self['covtype'])
+            kxprime = cov_gen(X1 = self['X0'], X2 = xprime, theta = self['theta'], type = self['covtype'])
             if self['trendtype'] == 'SK':
                 if x.shape[0] < xprime.shape[0]:
                     cov = self['nu_hat'] *  cov_gen(X1 = x, X2 = xprime, theta = self['theta'], type = self['covtype']) - kx @ self['Ki'] @ kxprime

--- a/tests/test_rpy2/test_hetGP_SK.py
+++ b/tests/test_rpy2/test_hetGP_SK.py
@@ -1,0 +1,91 @@
+import numpy as np
+from hetgpy import hetGP
+from hetgpy.example_data import mcycle
+from rpy2.robjects import r
+m = mcycle()
+
+    
+def test():
+    '''
+    Test performance of `trendtype`="SK"
+    Version 1.0.2 should "fail" (thanks to Ozge Surer, Miami Ohio)
+    Version 1.0.3+ should "pass"
+    '''
+
+    model = hetGP()
+    times, accel = m['times'], m['accel']
+    # simple kriging
+    Xgrid = np.linspace(times.min(),times.max(),100).reshape(-1,1)
+    known = dict(beta0=1,theta=np.array([10]),g=1e-3)
+    model.mle(X=times,Z=accel,covtype='Matern5_2',known=known,maxit=5)
+    
+    # hetGP SK
+    RStr = '''
+    library(hetGP)
+    library(MASS)
+    X = matrix(mcycle$times,ncol=1)
+    Delta = rep(-5,94)
+    Delta[94] = -2
+    Xgrid = matrix(seq(from=min(X),max(X),length.out=100),ncol=1)
+    Z = mcycle$accel
+    model = mleHetGP(X,Z,covtype="Matern5_2",known=list(beta0=1,theta=10,g=1e-3),maxit=5)
+    preds = predict(model,Xgrid)
+    '''
+    r(RStr)
+    # now "align" models by assigning core attributes from hetGP class
+    model.nu_hat = np.array(r('model$nu_hat')) 
+    #model.Delta = np.array(r('model$Delta'))
+    #model.Lambda = np.array(r('model$Lamda'))
+    model.Ki = np.array(r('model$Ki'))
+    model.C = np.array(r('model$C'))
+    #model.Cg = np.array(r('model$Cg'))
+    preds = model.predict(Xgrid)
+
+    # compare
+    predsR = dict(
+        sd2 = np.array(r('preds$sd2')),
+    )
+    assert np.allclose(preds['sd2'],predsR['sd2'])
+
+def test_OK():
+    '''
+    Same test as above but tests trendtype="OK" (ordinary kriging)
+    '''
+
+    model = hetGP()
+    times, accel = m['times'], m['accel']
+    # simple kriging
+    Xgrid = np.linspace(times.min(),times.max(),100).reshape(-1,1)
+    known = dict(theta=np.array([10]),g=1e-3)
+    model.mle(X=times,Z=accel,covtype='Matern5_2',known=known,maxit=5)
+    
+    # hetGP SK
+    RStr = '''
+    library(hetGP)
+    library(MASS)
+    X = matrix(mcycle$times,ncol=1)
+    Delta = rep(-5,94)
+    Delta[94] = -2
+    Xgrid = matrix(seq(from=min(X),max(X),length.out=100),ncol=1)
+    Z = mcycle$accel
+    model = mleHetGP(X,Z,covtype="Matern5_2",known=list(theta=10,g=1e-3),maxit=5)
+    preds = predict(model,Xgrid)
+    '''
+    r(RStr)
+    # now "align" models by assigning core attributes from hetGP class
+    model.nu_hat = np.array(r('model$nu_hat')) 
+    #model.Delta = np.array(r('model$Delta'))
+    #model.Lambda = np.array(r('model$Lamda'))
+    model.Ki = np.array(r('model$Ki'))
+    model.C = np.array(r('model$C'))
+    #model.Cg = np.array(r('model$Cg'))
+    preds = model.predict(Xgrid)
+
+    # compare
+    predsR = dict(
+        sd2 = np.array(r('preds$sd2')),
+    )
+    assert np.allclose(preds['sd2'],predsR['sd2'])
+
+if __name__ == "__main__":
+    test()


### PR DESCRIPTION
This pull request fixes some bugs in `hetGP.predict` when the trend is set to "SK" (simple kriging, or utilizing a known trend):
* removes extra `nu_hat` multiplication in `kxprime`
* fixes typo in kriging variance (`sd2`)

Added the test `tests/test_rpy2/test_hetGP_SK.py` which checks these calculations. Note that running this test on previous versions should fail (which is the expected behavior) but passes now.


Special thanks to Ozge Surer (U. of Miami, OH) for flagging these.