### PR TITLE
add SK OK options for test

### DIFF
--- a/tests/basic/test_cov_sd2.py
+++ b/tests/basic/test_cov_sd2.py
@@ -10,9 +10,16 @@ def _compare(X,Z,covtype,mtype='hetGP',beta0=None,verbose=False):
         model = hetGP()
     else:
         model = homGP()
-    model.mle(X=X,Z=Z,covtype=covtype,maxit=20,
-              lower=[0.5 for _ in range(X.shape[1])],
-              upper=[5 for _ in range(X.shape[1])])
+    known = {}
+    if beta0 is not None:
+        known['beta0'] = beta0
+    model.mle(
+        X=X,Z=Z,
+        covtype=covtype,maxit=20,
+        lower=[0.5 for _ in range(X.shape[1])],
+        upper=[5 for _ in range(X.shape[1])],
+        known=known
+    )
     
     if verbose:
         msg = f"Model {mtype}, {covtype} ran in {round(model.time,2)}"
@@ -23,18 +30,22 @@ def _compare(X,Z,covtype,mtype='hetGP',beta0=None,verbose=False):
 
 def test_mcycle(verbose=False):
     X, Z = m['times'], m['accel']
-    for mtype in ['hetGP','homGP']:
-        for ctype in ['Gaussian','Matern3_2','Matern5_2']:
-            res = _compare(X,Z,covtype=ctype,mtype=mtype,verbose=verbose)
-            assert res
+    beta0 = np.mean(Z)
+    for beta in [None,beta0]:
+        for mtype in ['hetGP','homGP']:
+            for ctype in ['Gaussian','Matern3_2','Matern5_2']:
+                res = _compare(X,Z,covtype=ctype,mtype=mtype,verbose=verbose,beta0=beta)
+                assert res
 
 def test_SIR(verbose=False):
     sir = loadmat('tests/data/SIR.mat') #2D example
     X, Z = sir['X'], sir['Y']
-    for mtype in ['hetGP','homGP']:
-        for ctype in ['Matern3_2','Matern5_2']: # Gaussian doesn't work for SIR model
-            res = _compare(X,Z,covtype=ctype,mtype=mtype,verbose=verbose)
-            assert res
+    beta0 = np.mean(Z)
+    for beta in [None,beta0]:
+        for mtype in ['hetGP','homGP']:
+            for ctype in ['Matern3_2','Matern5_2']: # no gaussian for SIR
+                res = _compare(X,Z,covtype=ctype,mtype=mtype,verbose=verbose,beta0=beta)
+                assert res
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Forgot to add functionality to differentiate between simple kriging and ordinary kriging in `tests/basic/test_cov_sd2.py`, but added now.