### PR TITLE
Adjust trace output for mleHetGP | fixes #32

### DIFF
--- a/hetgpy/hetGP.py
+++ b/hetgpy/hetGP.py
@@ -1213,7 +1213,7 @@ class hetGP:
                 idx = idx + len(init['Delta'])
                 # reconcile Deltas with R implementation
                 if trace > 1:
-                    for ii in range(np.ceil(len(mle_par['Delta'])/5)):
+                    for ii in range(np.ceil(len(mle_par['Delta'])/5).astype(np.uint64)):
                         i_tmp = np.arange(1 + 5*(ii-1),min(5*ii, len(mle_par['Delta'])))
                         if logN: print("Delta |", mle_par['Delta'][i_tmp], " | ", np.max(np.log(eps * mult[i_tmp]), init['Delta'][i_tmp] - np.log(1000)), " | ", init['Delta'][i_tmp] + np.log(100), "\n")
                         if not logN: print("Delta |", mle_par['Delta'][i_tmp], " | ", np.max(mult[i_tmp] * eps, init['Delta'][i_tmp] / 1000), " | ", init['Delta'][i_tmp] * 100, "\n")

--- a/hetgpy/hetGP.py
+++ b/hetgpy/hetGP.py
@@ -1214,7 +1214,7 @@ class hetGP:
                 # reconcile Deltas with R implementation
                 if trace > 1:
                     for ii in range(np.ceil(len(mle_par['Delta'])/5).astype(np.uint64)):
-                        i_tmp = np.arange(1 + 5*(ii-1),min(5*ii, len(mle_par['Delta'])))
+                        i_tmp = np.arange(5 * ii,min(5 * (ii + 1), len(mle_par['Delta'])))
                         if logN: 
                             print("Delta |", mle_par['Delta'][i_tmp], " | ", np.maximum(np.log(eps * mult[i_tmp]), init['Delta'][i_tmp] - np.log(1000)), " | ", init['Delta'][i_tmp] + np.log(100), "\n")
                         if not logN: print("Delta |", mle_par['Delta'][i_tmp], " | ", np.maximum(mult[i_tmp] * eps, init['Delta'][i_tmp] / 1000), " | ", init['Delta'][i_tmp] * 100, "\n")

--- a/hetgpy/hetGP.py
+++ b/hetgpy/hetGP.py
@@ -1215,8 +1215,9 @@ class hetGP:
                 if trace > 1:
                     for ii in range(np.ceil(len(mle_par['Delta'])/5).astype(np.uint64)):
                         i_tmp = np.arange(1 + 5*(ii-1),min(5*ii, len(mle_par['Delta'])))
-                        if logN: print("Delta |", mle_par['Delta'][i_tmp], " | ", np.max(np.log(eps * mult[i_tmp]), init['Delta'][i_tmp] - np.log(1000)), " | ", init['Delta'][i_tmp] + np.log(100), "\n")
-                        if not logN: print("Delta |", mle_par['Delta'][i_tmp], " | ", np.max(mult[i_tmp] * eps, init['Delta'][i_tmp] / 1000), " | ", init['Delta'][i_tmp] * 100, "\n")
+                        if logN: 
+                            print("Delta |", mle_par['Delta'][i_tmp], " | ", np.maximum(np.log(eps * mult[i_tmp]), init['Delta'][i_tmp] - np.log(1000)), " | ", init['Delta'][i_tmp] + np.log(100), "\n")
+                        if not logN: print("Delta |", mle_par['Delta'][i_tmp], " | ", np.maximum(mult[i_tmp] * eps, init['Delta'][i_tmp] / 1000), " | ", init['Delta'][i_tmp] * 100, "\n")
             if jointThetas:
                 if known.get('k_theta_g') is None:
                     mle_par['k_theta_g'] = out['par'][idx]


### PR DESCRIPTION
I resolved the described issue #32 by using `np.ceil(len(mle_par['Delta'])/5).astype(np.uint64)`.

When checking the output, a new error arose, which I tracked down to the use of `np.max`, while `np.maximum` is necessary for element-wise comparison. 

Finally, I noticed that the `Delta` array wasn't fully outputted in the log. This was due to R-style array indexing in the print statement. I adjusted it to Python-style indexing. 