### PR TITLE
add interval option to plot_diagnostics and correct '>' in plot label

### DIFF
--- a/hetgpy/plot.py
+++ b/hetgpy/plot.py
@@ -45,7 +45,7 @@ def plot_optimization_iterates(object, keys_and_title = None):
         i+=1
     return fig, ax
 
-def plot_diagnostics(model):
+def plot_diagnostics(model, interval:str='predictive'):
     r'''
     Diagnostics plot which mirrors the plot(model) routine in hetGP
     
@@ -54,22 +54,25 @@ def plot_diagnostics(model):
     Parameters
     ----------
     model: hetGPy model
+    interval: str
+        one of 'confidence' or 'predictive' 
 
     Returns
     -------
     fig, ax: matplotlib figure and axes
     '''
-    preds = model.predict(model.X0)
-    preds['upper'] = norm.ppf(0.95, loc = preds['mean'], scale = np.sqrt(preds['sd2'])).squeeze()
-    preds['lower'] = norm.ppf(0.05, loc = preds['mean'], scale = np.sqrt(preds['sd2'])).squeeze()
+    preds = model.predict(model.X0, interval=interval, interval_lower=0.05, interval_upper=0.95)
+    pred_interval = preds['confidence_interval'] if interval == 'confidence' else preds['predictive_interval']
+
 
     fig, ax = plt.subplots()
     idxs = np.repeat(np.arange(len(model.X0)),model.mult)
     ax.hlines(
         y=preds['mean'],
-        xmin=preds['lower'],
-        xmax=preds['upper'],
-        label='Prediction Interval',zorder=-10)
+        xmin=pred_interval['lower'],
+        xmax=pred_interval['upper'],
+        label='Prediction Interval' if interval == 'predictive' else 'Confidence Interval',
+        zorder=-10)
     ax.scatter(model.Z,
         preds['mean'][idxs],
         facecolors='none',
@@ -79,7 +82,7 @@ def plot_diagnostics(model):
 
     ax.scatter(model.Z0[(model.mult>1).nonzero()[0]],
             preds['mean'][(model.mult>1).nonzero()[0]],
-            label='Averages (if mult > 1)',color='red',zorder=10)
+            label=r'Averages (if mult \textgreater 1)',color='red',zorder=10)
     ax.legend(loc='upper left',edgecolor='black')
     ax.set_title('Model Diagnostics')
     ax.set_xlabel('Observed')


### PR DESCRIPTION
## Problem description

While checking the `plot_diagnostics` method, I was surprised by the small confidence intervals for my use case:

<img width="578" height="449" alt="Image" src="https://github.com/user-attachments/assets/629e785a-7c37-425d-b9ba-f7da29833df0" />

It was inconsistent with the prediction intervals generated using code similar to [one of the example notebooks](https://hetgpy.readthedocs.io/en/latest/examples/00-hetGPy-Intro.html). When looking at the source code, it appears that the confidence interval is computed by default, while the label states "Predictive interval". 

Also, note the > sign that is not rendered correctly by matplotlib.

## Suggested fix

I have added a parameter `interval` to the function inputs that distinguishes between a confidence or predictive interval. Now the resulting plot is:

<img width="578" height="449" alt="image" src="https://github.com/user-attachments/assets/ed9af39d-3372-43c6-9282-a485763b1ef9" />

The function documentation mentions that this function was written to mirror the plot(model) routine in hetGP. I am unsure if this new code aligns with the hetGP implementation. 